### PR TITLE
firefox: add gtk3-immodule-wayland runtime dep

### DIFF
--- a/meta-firefox/recipes-browser/firefox/firefox.inc
+++ b/meta-firefox/recipes-browser/firefox/firefox.inc
@@ -132,7 +132,7 @@ PACKAGECONFIG ??= "${@bb.utils.contains("DISTRO_FEATURES", "alsa", "alsa", "", d
                    ${@bb.utils.contains_any("TARGET_ARCH", "x86_64 arm aarch64", "webrtc", "", d)} \
 "
 PACKAGECONFIG[alsa] = "--enable-alsa,--disable-alsa,alsa-lib"
-PACKAGECONFIG[wayland] = "--enable-default-toolkit=cairo-gtk3-wayland,--enable-default-toolkit=cairo-gtk3,virtual/egl,"
+PACKAGECONFIG[wayland] = "--enable-default-toolkit=cairo-gtk3-wayland,--enable-default-toolkit=cairo-gtk3,virtual/egl,gtk3-immodule-wayland"
 PACKAGECONFIG[gpu] = ",,,"
 PACKAGECONFIG[openmax] = "--enable-openmax,,,"
 PACKAGECONFIG[webgl] = ",,,"


### PR DESCRIPTION
this ensures that input-method events are sent by wayland to on-screen keyboards