### PR TITLE
Fix addon enabling

### DIFF
--- a/meta-firefox/recipes-browser/firefox/firefox/prefs/vendor.js
+++ b/meta-firefox/recipes-browser/firefox/firefox/prefs/vendor.js
@@ -7,4 +7,3 @@ pref("devtools.webide.autoinstallFxdtAdapters", false);
 // Forbid application updates
 lockPref("app.update.enabled", false);
 lockPref("extensions.update.enabled", false);
-lockPref("extensions.autoDisableScopes", 10);

--- a/meta-firefox/recipes-devtools/nspr/nspr-4.35.bb
+++ b/meta-firefox/recipes-devtools/nspr/nspr-4.35.bb
@@ -20,7 +20,7 @@ SRC_URI = "http://ftp.mozilla.org/pub/nspr/releases/v${PV}/src/nspr-${PV}.tar.gz
            file://nspr.pc.in \
            "
 
-CACHED_CONFIGUREVARS_append_libc-musl = " CFLAGS='${CFLAGS} -D_PR_POLL_AVAILABLE \
+CACHED_CONFIGUREVARS:append:libc-musl = " CFLAGS='${CFLAGS} -D_PR_POLL_AVAILABLE \
                                           -D_PR_HAVE_LARGE_OFF_T -D_PR_INET6 -D_PR_HAVE_INET_NTOP \
                                           -D_PR_HAVE_GETHOSTBYNAME2 -D_PR_HAVE_GETADDRINFO \
                                           -D_PR_INET6_PROBE -DNO_DLOPEN_NULL'"
@@ -164,17 +164,17 @@ PACKAGECONFIG[ipv6] = "--enable-ipv6,--disable-ipv6,"
 # preferred path upstream.
 EXTRA_OECONF += "--includedir=${includedir}/nspr"
 
-EXTRA_OEMAKE_append_class-native = " EXTRA_LIBS='-lpthread -lrt -ldl'"
+EXTRA_OEMAKE:append:class-native = " EXTRA_LIBS='-lpthread -lrt -ldl'"
 
-do_compile_prepend() {
+do_compile:prepend() {
 	oe_runmake CROSS_COMPILE=1 CFLAGS="-DXP_UNIX ${BUILD_CFLAGS}" LDFLAGS="" CC="${BUILD_CC}" -C config export
 }
 
-do_compile_append() {
+do_compile:append() {
 	oe_runmake -C pr/tests
 }
 
-do_install_append() {
+do_install:append() {
     install -D ${WORKDIR}/nspr.pc.in ${D}${libdir}/pkgconfig/nspr.pc
     sed -i  \
     -e 's:NSPRVERSION:${PV}:g' \
@@ -196,8 +196,8 @@ do_install_append() {
     rm ${D}${bindir}/compile-et.pl ${D}${bindir}/prerr.properties
 }
 
-FILES_${PN} = "${libdir}/lib*.so"
-FILES_${PN}-dev = "${bindir}/* ${libdir}/nspr/tests/* ${libdir}/pkgconfig \
+FILES:${PN} = "${libdir}/lib*.so"
+FILES:${PN}-dev = "${bindir}/* ${libdir}/nspr/tests/* ${libdir}/pkgconfig \
                 ${includedir}/* ${datadir}/aclocal/* "
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Remove the locked preference for `extensions.autoDisableScopes`

The value of this preference disables addons, depending on where they are installed. The value of this preference in the sum of the following values:

| Value | Name/Scope |
| -------- | --------- |
| 1         | PROFILE (~/.mozilla/$PROFILE folder)|
| 2         | USER  (~/.mozilla/extensions folder)|
| 4         | APPLICATION (/usr/lib/firefox/browser/features) |
| 8         | SYSTEM (/usr/share/mozilla/extensions, /usr/lib/mozilla/extensions, /usr/lib64/mozilla/extensions)|

The original value, 10, restricted enabling addons from the system-wide and user folders.

This shouldn't be restricted by default, but left to the user if they want to customize it. -> remove it

Issue #50 