### PR TITLE
firefox: document and clean up dependencies

### DIFF
--- a/meta-firefox/README.md
+++ b/meta-firefox/README.md
@@ -25,8 +25,9 @@ Firefox can be successfully compiled with the following dependencies and branche
 | Kirkstone     | [Kirkstone](https://github.com/openembedded/meta-openembedded/commit/529620141e773080a6a7be4615fb7993204af883)  | [Kirkstone](https://git.yoctoproject.org/poky/commit/?h=kirkstone&id=75239ddd8d67c00139c6e88c1c2a790b471b12c5) | [Kirkstone](https://github.com/kraj/meta-clang/commit/2d08d6bf376a1e06c53164fd6283b03ec2309da4) | [Master](https://github.com/meta-rust/meta-rust/commit/e3082dc0728023b121d648da4c5c856943b5e425) |
 | Mickledore    | [Mickledore](https://github.com/openembedded/meta-openembedded/commit/922f41b39f364e5b6be596b4b51e0fb37ffe1971) | [Mickledore](https://git.yoctoproject.org/poky/commit/?h=mickledore&id=a57506c46d92bf0767060102d2139be06d46f575) | [Master](https://github.com/kraj/meta-clang/commit/869df95b61ba44a7ad6bc57da8a31e459eec5059)  | N/A       |
 | Nanbield      | [Nanbield](https://github.com/openembedded/meta-openembedded/commit/278c3f75e32f38f71bb52d161fe06bcb6f6bdd2f) | [Nanbield](https://git.yoctoproject.org/poky/commit/?h=nanbield&id=0e351df0425968fd58983e445391012e64f7f4ad)  | [Master](https://github.com/kraj/meta-clang/commit/869df95b61ba44a7ad6bc57da8a31e459eec5059) | N/A       |
+| Scarthgap     | [master-next](https://github.com/openembedded/meta-openembedded/commit/a64b63c0a1ae74199043cf699cf93a171364980d) | [Scarthgap](https://git.yoctoproject.org/poky/commit/?h=scarthgap&id=b5624ee5643d881afa004571a096a189ab5389b5) | [Nanbield](https://github.com/kraj/meta-clang/commit/5170ec9cdfe215fcef146fa9142521bfad1d7d6c) | N/A       |
 
-Mickledore and Nanbield work with the Rust recipes included in poky.
+Mickledore, Nanbield and Scarthgap work with the Rust recipes included in poky.
 
 Kirkstone however has a too old Rust version, and Dunfell has no Rust.
 These versions require the meta-rust layer also. For Kirkstone make sure to set the 
@@ -141,3 +142,60 @@ Runtime options
 ---------------
 * The enviromental variable `GDK_BACKEND=wayland` is needed to run Firefox with
   the wayland backend.
+
+Source for "magic" commits
+========================
+While the source tarballs contains *most* of the compile dependencies, unfortunately some are missing, making it 
+impossible to build Firefox without network connection. Due to this the Rust crates are downloaded directly 
+(the list of downloaded crates and their version is taken from the `third_party/rust` folder), and some are downloaded
+from git directly (for the most part these were gathered from the top level `Cargo.toml`). This section hopefully
+documents where those magic commit hashes come from. (And will also be helpful for me, when I'm trying to figure
+out where a specific dependency is coming from during updating to new versions).
+
+In case a dependency is required by multiple sources, and they specify different versions, the latest version is
+taken into account only.
+
+Note: the dependency column refers to the `destsuffix` used in the recipes.
+
+| Firefox version | Dependency | Used commit | Source / Comment |
+| --------------- | ---------- | -------------- | ---------------- |
+| 115.8.0esr | application-services | 86c84c217036c12283d19368867323a66bf35883 | This involves a collection of crates developed by Mozilla. These are specified in the top level Cargo.toml, by explicit hash. (interrupt-support, sql-support, sync15, tabs, viaduct, webext-storage) |
+| 115.8.0esr | packed-simd | e588ceb568878e1a3156ea9ce551d5b63ef0cdc4 | Specified in top level Cargo.toml, by explicit hash. |
+| 115.8.0esr | d3d12-rs | b940b1d71ab7083ae80eec697872672dc1f2bd32 | This commit is required explicitly by `third_party/rust/wgpu-hal/Cargo.toml`. |
+| 115.8.0esr | neqo | 80db3a01f3273c7e742ba560fa99246fc8b30c4f | This commit corresponds to version 0.6.4, which is required by `netwerk/socket/neqo_glue/Cargo.toml` |
+| 115.8.0esr | mp4parse | cf8b0e04de9c60f38f7f057f9f29c74d19336d0c | This commit is required explicitly by `toolkit/library/rust/shared/Cargo.toml` |
+| 115.8.0esr | wgpu | f71a1bc736fde37509262ca03e91d8f56a13aeb5 | This commit is required explicitly by `gfx/wgpu_bindings/Cargo.toml` |
+| 115.8.0esr | naga | b99d58ea435090e561377949f428bce2c18451bb | This commit is required explicitly by `third_party/rust/wgpu-hal/Cargo.toml` |
+| 115.8.0esr | uniffi-rs | bc7ff8977bf38d0fdd1a458810b14f434d4dc4de | This commit corresponds to version 0.23.0, which is specified by the top level Cargo.toml |
+| 115.8.0esr | audioipc | 0b51291d2483a17dce3e300c7784b369e02bee73 | This commit is required explicitly by `toolkit/library/rust/shared/Cargo.toml` |
+| 115.8.0esr | wpf-gpu-raster | 5ab6fe33d00021325ee920b3c10526dc8301cf46 | This commit is required explicitly by `toolkit/library/rust/shared/Cargo.toml` |
+| 115.8.0esr | warp | 4af45fae95bc98b0eba1ef0db17e1dac471bb23d | This commit is required explicitly by the top level Cargo.toml |
+| 115.8.0esr | cubeb-pulse | cf48897be5cbe147d051ebbbe1eaf5fd8fb6bbc9 | This commit is required explicitly by `toolkit/library/rust/shared/Cargo.toml` |
+| 115.8.0esr | midir | 519e651241e867af3391db08f9ae6400bc023e18 | This commit is required explicitly by the top level Cargo.toml |
+| 115.8.0esr | cubeb-coreaudio | 93b5c01a131f65c83c11aeb317f4583405c5eb79 | Required explicitly by `./toolkit/library/rust/shared/Cargo.toml`. |
+| 115.8.0esr | aa-stroke | 07d3c25322518f294300e96246e09b95e118555d | Required explicitly by `./toolkit/library/rust/shared/Cargo.toml`. |
+| 115.8.0esr | jsparagus | 64ba08e24749616de2344112f226d1ef4ba893ae | Required explicitly by `js/src/frontend/smoosh/Cargo.toml`. |
+| 123.0.1 | application-services | 63a6260c14847c21c5a1fa3003efaf0114a3e4e5 | This involves a collection of crates developed by Mozilla. These are specified in the top level Cargo.toml, by explicit hash. (interrupt-support, sql-support, sync15, tabs, viaduct, webext-storage, suggest) |
+| 123.0.1 | cose-rust | 43c22248d136c8b38fe42ea709d08da6355cf04b | This commit is required explicitly by the top level Cargo.toml |
+| 123.0.1 | minidump-writer | 99c561931fe8cf1fa2135b3f23ff6588bef8fd1e | This commit corresponds to version 0.8.3, which is a dependency of `toolkit/crashreporter/rust_minidump_writer_linux/Cargo.toml` |
+| 123.0.1 | minidump-common | c3de84b061339c686a572fb9f059e7ba3fad38d6 | This commit corresponds to version 1.19.1, which is specified by `third_party/rust/minidump-writer/Cargo.toml` |
+| 123.0.1 | packed-simd | d938e39bee9bc5c222f5f2f2a0df9e53b5ce36ae | This commit corresponds to v0.3.9, which is required by `./third_party/rust/encoding_rs/Cargo.toml`. |
+| 123.0.1 | mp4parse | d262e40e7b80f949dcdb4db21caa6dbf1a8b2043 | This commit is required explicitly by `toolkit/library/rust/shared/Cargo.toml` |
+| 123.0.1 | neqo | 83735a88217a6b3a6a9d3cd5d9243040c5e41319 | This commit corresponds to v0.6.8, which is required by `netwerk/socket/neqo_glue/Cargo.toml` | 
+| 123.0.1 | wgpu | c6eea50b04127abe2340b93141123312baf5414b | This commit is required explicitly by `gfx/wgpu_bindings/Cargo.toml` |
+| 123.0.1 | naga | 92e41b43e437146b5d946eb238de963be1168016 | This commit corresponds to v0.14.0, which is required by `wgpu-core` and `wgpu-hal` (previous entry) |
+| 123.0.1 | uniffi-rs | afb29ebdc1d9edf15021b1c5332fc9f285bbe13b | This commit corresponds to v0.25.3, which is referred by the top level Cargo.toml. |
+| 123.0.1 | metal | f507da4686234e658f31de54d2aa0dfa8abd236b | This is version v0.27.0, which is required by `wgpu-hal` (above) |
+| 123.0.1 | cssparser | aaa966d9d6ae70c4b8a62bb5e3a14c068bb7dff0 | This commit is required explicitly by the top level Cargo.toml |
+| 123.0.1 | audioipc | 6be424d75f1367e70f2f5ddcacd6d0237e81a6a9 | This commit is required explicitly by `toolkit/library/rust/shared/Cargo.toml` |
+| 123.0.1 | wpf-gpu-raster | 99979da091fd58fba8477e7fcdf5ec0727102916 | This commit is required explicitly by `toolkit/library/rust/shared/Cargo.toml` |
+| 123.0.1 | warp | 9d081461ae1167eb321585ce424f4fef6cf0092b | This commit is required explicitly by the top level Cargo.toml |
+| 123.0.1 | cubeb-pulse | c04c4d2c7f2291cb81a1c48f5a8c425748f18cd8 | This commit is required explicitly by `toolkit/library/rust/shared/Cargo.toml` |
+| 123.0.1 | cubeb-coreaudio | 89abc256a2eab3398f880e114b2d8308f5bc1d1a | Required explicitly by `./toolkit/library/rust/shared/Cargo.toml`. |
+| 123.0.1 | midir | 85156e360a37d851734118104619f86bd18e94c6 | This commit is required explicitly by the top level Cargo.toml |
+| 123.0.1 | aa-stroke | ed4206ea11703580cd1d4fc63371a527b29d8252 | Required explicitly by `./toolkit/library/rust/shared/Cargo.toml`. |
+| 123.0.1 | jsparagus | 61f399c53a641ebd3077c1f39f054f6d396a633c | Required explicitly by `js/src/frontend/smoosh/Cargo.toml`.|
+| common | chardetng | 3484d3e3ebdc8931493aa5df4d7ee9360a90e76b | This commit is required explicitly by the top level Cargo.toml |
+| common | chardetng_c | ed8a4c6f900a90d4dbc1d64b856e61490a1c3570 | This commit is required explicitly by the top level Cargo.toml |
+| common | coremidi | fc68464b5445caf111e41f643a2e69ccce0b4f83 | This commit is required explicitly by the top level Cargo.toml |
+| common | mapped_hyph | c7651a0cffff41996ad13c44f689bd9cd2192c01 | Required explicitly by `./toolkit/library/rust/shared/Cargo.toml`. |

--- a/meta-firefox/recipes-browser/firefox/firefox-esr/0002-use-offline-crates.patch
+++ b/meta-firefox/recipes-browser/firefox/firefox-esr/0002-use-offline-crates.patch
@@ -1,7 +1,66 @@
 Upstream-Status: Inappropriate
---- ./Cargo.toml	2023-09-28 05:15:58.000000000 +0200
-+++ ./Cargo.toml	2023-10-17 18:28:10.579673964 +0200
-@@ -159,32 +159,77 @@
+--- ./.cargo/config.in	2023-10-17 18:53:06.226955914 +0200
++++ ./.cargo/config.in	2023-10-17 19:01:16.674613434 +0200
+@@ -125,4 +125,4 @@
+ # cargo will ignore it when it's here verbatim.
+ #filter substitution
+ [source."@REPLACE_NAME@"]
+-directory = "@top_srcdir@/@VENDORED_DIRECTORY@"
++directory = "../../cargo_home/bitbake"
+--- ./gfx/wgpu_bindings/Cargo.toml.orig	2023-12-19 16:12:09.745686495 +0100
++++ ./gfx/wgpu_bindings/Cargo.toml	2023-12-19 16:14:00.983568703 +0100
+@@ -16,8 +16,7 @@
+ 
+ [dependencies.wgc]
+ package = "wgpu-core"
+-git = "https://github.com/gfx-rs/wgpu"
+-rev = "f71a1bc736fde37509262ca03e91d8f56a13aeb5"
++path = "../../../wgpu/wgpu-core"
+ #Note: "replay" shouldn't ideally be needed,
+ # but it allows us to serialize everything across IPC.
+ features = ["replay", "trace", "serial-pass", "strict_asserts", "wgsl"]
+@@ -26,33 +25,28 @@
+ # (We should consider also enabling "vulkan" for Vulkan Portability.)
+ [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies.wgc]
+ package = "wgpu-core"
+-git = "https://github.com/gfx-rs/wgpu"
+-rev = "f71a1bc736fde37509262ca03e91d8f56a13aeb5"
++path = "../../../wgpu/wgpu-core"
+ features = ["metal"]
+ 
+ # We want the wgpu-core Direct3D backends on Windows.
+ [target.'cfg(windows)'.dependencies.wgc]
+ package = "wgpu-core"
+-git = "https://github.com/gfx-rs/wgpu"
+-rev = "f71a1bc736fde37509262ca03e91d8f56a13aeb5"
++path = "../../../wgpu/wgpu-core"
+ features = ["dx11", "dx12"]
+ 
+ # We want the wgpu-core Vulkan backend on Linux and Windows.
+ [target.'cfg(any(windows, all(unix, not(any(target_os = "macos", target_os = "ios")))))'.dependencies.wgc]
+ package = "wgpu-core"
+-git = "https://github.com/gfx-rs/wgpu"
+-rev = "f71a1bc736fde37509262ca03e91d8f56a13aeb5"
++path = "../../../wgpu/wgpu-core"
+ features = ["vulkan"]
+ 
+ [dependencies.wgt]
+ package = "wgpu-types"
+-git = "https://github.com/gfx-rs/wgpu"
+-rev = "f71a1bc736fde37509262ca03e91d8f56a13aeb5"
++path = "../../../wgpu/wgpu-types"
+ 
+ [dependencies.wgh]
+ package = "wgpu-hal"
+-git = "https://github.com/gfx-rs/wgpu"
+-rev = "f71a1bc736fde37509262ca03e91d8f56a13aeb5"
++path = "../../../wgpu/wgpu-hal"
+ 
+ [dependencies]
+ bincode = "1"
+--- ./Cargo.toml	2024-02-12 21:53:02.000000000 +0100
++++ ./Cargo.toml	2024-03-14 13:33:31.890247372 +0100
+@@ -159,32 +159,75 @@
  cssparser-macros = { path = "third_party/rust/cssparser-macros" }
  
  # Other overrides
@@ -34,8 +93,6 @@ Upstream-Status: Inappropriate
 +tabs = { path = "../application-services/components/tabs", version = "0.1.0" }
 +viaduct = { path = "../application-services/components/viaduct", version = "0.1.0" }
 +webext-storage = { path = "../application-services/components/webext-storage", version = "0.1.0" }
-+
-+# syn = { path = "../syn", version = "2.0.38" }
  
  # Patch mio 0.6 to use winapi 0.3 and miow 0.3, getting rid of winapi 0.2.
  # There is not going to be new version of mio 0.6, mio now being >= 0.7.11.
@@ -96,62 +153,3 @@ Upstream-Status: Inappropriate
 +
 +[patch."https://github.com/gfx-rs/d3d12-rs"]
 +d3d12 = { path = "../d3d12-rs" }
---- ./.cargo/config.in	2023-10-17 18:53:06.226955914 +0200
-+++ ./.cargo/config.in	2023-10-17 19:01:16.674613434 +0200
-@@ -125,4 +125,4 @@
- # cargo will ignore it when it's here verbatim.
- #filter substitution
- [source."@REPLACE_NAME@"]
--directory = "@top_srcdir@/@VENDORED_DIRECTORY@"
-+directory = "../../cargo_home/bitbake"
---- ./gfx/wgpu_bindings/Cargo.toml.orig	2023-12-19 16:12:09.745686495 +0100
-+++ ./gfx/wgpu_bindings/Cargo.toml	2023-12-19 16:14:00.983568703 +0100
-@@ -16,8 +16,7 @@
- 
- [dependencies.wgc]
- package = "wgpu-core"
--git = "https://github.com/gfx-rs/wgpu"
--rev = "f71a1bc736fde37509262ca03e91d8f56a13aeb5"
-+path = "../../../wgpu/wgpu-core"
- #Note: "replay" shouldn't ideally be needed,
- # but it allows us to serialize everything across IPC.
- features = ["replay", "trace", "serial-pass", "strict_asserts", "wgsl"]
-@@ -26,33 +25,28 @@
- # (We should consider also enabling "vulkan" for Vulkan Portability.)
- [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies.wgc]
- package = "wgpu-core"
--git = "https://github.com/gfx-rs/wgpu"
--rev = "f71a1bc736fde37509262ca03e91d8f56a13aeb5"
-+path = "../../../wgpu/wgpu-core"
- features = ["metal"]
- 
- # We want the wgpu-core Direct3D backends on Windows.
- [target.'cfg(windows)'.dependencies.wgc]
- package = "wgpu-core"
--git = "https://github.com/gfx-rs/wgpu"
--rev = "f71a1bc736fde37509262ca03e91d8f56a13aeb5"
-+path = "../../../wgpu/wgpu-core"
- features = ["dx11", "dx12"]
- 
- # We want the wgpu-core Vulkan backend on Linux and Windows.
- [target.'cfg(any(windows, all(unix, not(any(target_os = "macos", target_os = "ios")))))'.dependencies.wgc]
- package = "wgpu-core"
--git = "https://github.com/gfx-rs/wgpu"
--rev = "f71a1bc736fde37509262ca03e91d8f56a13aeb5"
-+path = "../../../wgpu/wgpu-core"
- features = ["vulkan"]
- 
- [dependencies.wgt]
- package = "wgpu-types"
--git = "https://github.com/gfx-rs/wgpu"
--rev = "f71a1bc736fde37509262ca03e91d8f56a13aeb5"
-+path = "../../../wgpu/wgpu-types"
- 
- [dependencies.wgh]
- package = "wgpu-hal"
--git = "https://github.com/gfx-rs/wgpu"
--rev = "f71a1bc736fde37509262ca03e91d8f56a13aeb5"
-+path = "../../../wgpu/wgpu-hal"
- 
- [dependencies]
- bincode = "1"

--- a/meta-firefox/recipes-browser/firefox/firefox-stable/0002-use-offline-crates.patch
+++ b/meta-firefox/recipes-browser/firefox/firefox-stable/0002-use-offline-crates.patch
@@ -10,117 +10,6 @@ Upstream-status: Inappropriate
  third_party/rust/suggest/Cargo.toml |  8 +--
  3 files changed, 69 insertions(+), 33 deletions(-)
 
---- ./Cargo.toml	2024-02-19 18:28:30.167362766 +0100
-+++ ./Cargo.toml	2024-02-19 18:33:06.431115830 +0100
-@@ -182,33 +182,71 @@
- rure = { path = "third_party/rust/rure" }
- 
- # To-be-published changes.
--cssparser = { git = "https://github.com/servo/rust-cssparser", rev = "aaa966d9d6ae70c4b8a62bb5e3a14c068bb7dff0" }
--cssparser-macros = { git = "https://github.com/servo/rust-cssparser", rev = "aaa966d9d6ae70c4b8a62bb5e3a14c068bb7dff0" }
-+cssparser = { path = "../cssparser" }
-+cssparser-macros = { path = "../cssparser/macros" }
- 
- # Other overrides
--chardetng = { git = "https://github.com/hsivonen/chardetng", rev = "3484d3e3ebdc8931493aa5df4d7ee9360a90e76b" }
--chardetng_c = { git = "https://github.com/hsivonen/chardetng_c", rev = "ed8a4c6f900a90d4dbc1d64b856e61490a1c3570" }
--coremidi = { git = "https://github.com/chris-zen/coremidi.git", rev = "fc68464b5445caf111e41f643a2e69ccce0b4f83" }
--cose = { git = "https://github.com/franziskuskiefer/cose-rust", rev = "43c22248d136c8b38fe42ea709d08da6355cf04b" }
-+chardetng = { path = "../chardetng" }
-+chardetng_c = { path = "../chardetng_c" }
-+coremidi = { path = "../coremidi" }
-+cose = { path = "../cose-rust" }
- firefox-on-glean = { path = "toolkit/components/glean/api" }
- icu_capi = { path = "intl/icu_capi" }
- icu_segmenter_data = { path = "intl/icu_segmenter_data" }
- libudev-sys = { path = "dom/webauthn/libudev-sys" }
--midir = { git = "https://github.com/mozilla/midir.git", rev = "85156e360a37d851734118104619f86bd18e94c6" }
-+midir = { path = "../midir" }
- # warp 0.3.6 + https://github.com/seanmonstar/warp/pull/1069
--warp = { git = "https://github.com/seanmonstar/warp", rev = "9d081461ae1167eb321585ce424f4fef6cf0092b" }
-+warp = { path = "../warp" }
- # Allow webrender to have a versioned dependency on the older crate on crates.io
- # in order to build standalone.
- malloc_size_of_derive = { path = "xpcom/rust/malloc_size_of_derive" }
- 
- # application-services overrides to make updating them all simpler.
--interrupt-support = { git = "https://github.com/mozilla/application-services", rev = "63a6260c14847c21c5a1fa3003efaf0114a3e4e5" }
--sql-support = { git = "https://github.com/mozilla/application-services", rev = "63a6260c14847c21c5a1fa3003efaf0114a3e4e5" }
--suggest = { git = "https://github.com/mozilla/application-services", rev = "63a6260c14847c21c5a1fa3003efaf0114a3e4e5" }
--sync15 = { git = "https://github.com/mozilla/application-services", rev = "63a6260c14847c21c5a1fa3003efaf0114a3e4e5" }
--tabs = { git = "https://github.com/mozilla/application-services", rev = "63a6260c14847c21c5a1fa3003efaf0114a3e4e5" }
--viaduct = { git = "https://github.com/mozilla/application-services", rev = "63a6260c14847c21c5a1fa3003efaf0114a3e4e5" }
--webext-storage = { git = "https://github.com/mozilla/application-services", rev = "63a6260c14847c21c5a1fa3003efaf0114a3e4e5" }
-+interrupt-support = { path = "../application-services/components/support/interrupt", version = "0.1.0" }
-+sql-support = { path = "../application-services/components/support/sql", version = "0.1.0" }
-+sync15 = { path = "../application-services/components/sync15", version = "0.1.0" }
-+tabs = { path = "../application-services/components/tabs", version = "0.1.0" }
-+viaduct = { path = "third_party/rust/viaduct", version = "0.1.0" }
-+webext-storage = { path = "../application-services/components/webext-storage", version = "0.1.0" }
-+suggest = { path = "third_party/rust/suggest" }
-+
-+diplomat = { path = "../diplomat/macro" }
-+diplomat-runtime = { path = "../diplomat/runtime" }
-+icu_provider_macros = { path = "../icu4x/provider/macros" }
-+yoke-derive = { path = "../icu4x/utils/yoke/derive" }
-+zerofrom-derive = { path = "../icu4x/utils/zerofrom/derive" }
-+zerovec-derive = { path = "../icu4x/utils/zerovec/derive" }
-+
-+metal = { path = "../metal" }
-+
-+[patch."https://github.com/mozilla-spidermonkey/jsparagus"]
-+jsparagus = { path = "../jsparagus" }
-+
-+[patch."https://github.com/mozilla/neqo"]
-+neqo-http3 = { path = "../neqo/neqo-http3", version = "0.6.5" }
-+neqo-common = { path = "../neqo/neqo-common", version = "0.6.5" }
-+neqo-transport = { path = "../neqo/neqo-transport", version = "0.6.5" }
-+neqo-qpack = { path = "../neqo/neqo-qpack", version = "0.6.5" }
-+neqo-crypto = { path = "../neqo/neqo-crypto", version = "0.6.5" }
-+
-+[patch."https://github.com/FirefoxGraphics/aa-stroke"]
-+aa-stroke = { path = "../aa-stroke"}
-+
-+[patch."https://github.com/mozilla/audioipc"]
-+audioipc2-client = { path = "../audioipc/client" }
-+audioipc2-server = { path = "../audioipc/server" }
-+
-+[patch."https://github.com/mozilla/cubeb-coreaudio-rs"]
-+cubeb-coreaudio = { path = "../cubeb-coreaudio" }
-+
-+[patch."https://github.com/mozilla/cubeb-pulse-rs"]
-+cubeb-pulse = { path = "../cubeb-pulse" }
-+
-+[patch."https://github.com/jfkthame/mapped_hyph.git"]
-+mapped_hyph = { path = "../mapped_hyph" }
-+
-+[patch."https://github.com/mozilla/mp4parse-rust"]
-+mp4parse_capi = { path = "../mp4parse/mp4parse_capi", version = "0.17.0" }
- 
- # Patch mio 0.6 to use winapi 0.3 and miow 0.3, getting rid of winapi 0.2.
- # There is not going to be new version of mio 0.6, mio now being >= 0.7.11.
-@@ -216,8 +254,16 @@
- path = "third_party/rust/mio-0.6.23"
- 
- [patch."https://github.com/mozilla/uniffi-rs.git"]
--uniffi = "=0.25.3"
--uniffi_bindgen = "=0.25.3"
--uniffi_build = "=0.25.3"
--uniffi_macros = "=0.25.3"
--weedle2 = "=4.0.0"
-+uniffi-example-arithmetic = { path = "../uniffi-rs/examples/arithmetic" }
-+uniffi-example-geometry = { path = "../uniffi-rs/examples/geometry" }
-+uniffi-example-rondpoint = { path = "../uniffi-rs/examples/rondpoint" }
-+uniffi-example-sprites = { path = "../uniffi-rs/examples/sprites" }
-+uniffi-example-todolist = { path = "../uniffi-rs/examples/todolist" }
-+
-+[patch."https://github.com/FirefoxGraphics/wpf-gpu-raster"]
-+wpf-gpu-raster = { path = "../wpf-gpu-raster" }
-+
-+[patch."https://github.com/gfx-rs/wgpu"]
-+wgpu-core = { path = "../wgpu/wgpu-core" }
-+wgpu-types = { path = "../wgpu/wgpu-types" }
-+wgpu-hal = { path = "../wgpu/wgpu-hal" }
 --- ./.cargo/config.in	2024-02-19 18:37:17.820994705 +0100
 +++ ./.cargo/config.in	2024-02-19 18:41:22.292904599 +0100
 @@ -120,4 +120,4 @@
@@ -209,3 +98,107 @@ Upstream-status: Inappropriate
  [dependencies.url]
  version = "2.1"
  features = ["serde"]
+--- ./Cargo.toml	2024-03-04 13:24:51.000000000 +0100
++++ ./Cargo.toml	2024-03-14 13:26:22.929973414 +0100
+@@ -182,33 +182,64 @@
+ rure = { path = "third_party/rust/rure" }
+ 
+ # To-be-published changes.
+-cssparser = { git = "https://github.com/servo/rust-cssparser", rev = "aaa966d9d6ae70c4b8a62bb5e3a14c068bb7dff0" }
+-cssparser-macros = { git = "https://github.com/servo/rust-cssparser", rev = "aaa966d9d6ae70c4b8a62bb5e3a14c068bb7dff0" }
++cssparser = { path = "../cssparser" }
++cssparser-macros = { path = "../cssparser/macros" }
+ 
+ # Other overrides
+-chardetng = { git = "https://github.com/hsivonen/chardetng", rev = "3484d3e3ebdc8931493aa5df4d7ee9360a90e76b" }
+-chardetng_c = { git = "https://github.com/hsivonen/chardetng_c", rev = "ed8a4c6f900a90d4dbc1d64b856e61490a1c3570" }
+-coremidi = { git = "https://github.com/chris-zen/coremidi.git", rev = "fc68464b5445caf111e41f643a2e69ccce0b4f83" }
+-cose = { git = "https://github.com/franziskuskiefer/cose-rust", rev = "43c22248d136c8b38fe42ea709d08da6355cf04b" }
++chardetng = { path = "../chardetng" }
++chardetng_c = { path = "../chardetng_c" }
++coremidi = { path = "../coremidi" }
++cose = { path = "../cose-rust" }
+ firefox-on-glean = { path = "toolkit/components/glean/api" }
+ icu_capi = { path = "intl/icu_capi" }
+ icu_segmenter_data = { path = "intl/icu_segmenter_data" }
+ libudev-sys = { path = "dom/webauthn/libudev-sys" }
+-midir = { git = "https://github.com/mozilla/midir.git", rev = "85156e360a37d851734118104619f86bd18e94c6" }
++midir = { path = "../midir" }
+ # warp 0.3.6 + https://github.com/seanmonstar/warp/pull/1069
+-warp = { git = "https://github.com/seanmonstar/warp", rev = "9d081461ae1167eb321585ce424f4fef6cf0092b" }
++warp = { path = "../warp" }
+ # Allow webrender to have a versioned dependency on the older crate on crates.io
+ # in order to build standalone.
+ malloc_size_of_derive = { path = "xpcom/rust/malloc_size_of_derive" }
+ 
+ # application-services overrides to make updating them all simpler.
+-interrupt-support = { git = "https://github.com/mozilla/application-services", rev = "63a6260c14847c21c5a1fa3003efaf0114a3e4e5" }
+-sql-support = { git = "https://github.com/mozilla/application-services", rev = "63a6260c14847c21c5a1fa3003efaf0114a3e4e5" }
+-suggest = { git = "https://github.com/mozilla/application-services", rev = "63a6260c14847c21c5a1fa3003efaf0114a3e4e5" }
+-sync15 = { git = "https://github.com/mozilla/application-services", rev = "63a6260c14847c21c5a1fa3003efaf0114a3e4e5" }
+-tabs = { git = "https://github.com/mozilla/application-services", rev = "63a6260c14847c21c5a1fa3003efaf0114a3e4e5" }
+-viaduct = { git = "https://github.com/mozilla/application-services", rev = "63a6260c14847c21c5a1fa3003efaf0114a3e4e5" }
+-webext-storage = { git = "https://github.com/mozilla/application-services", rev = "63a6260c14847c21c5a1fa3003efaf0114a3e4e5" }
++interrupt-support = { path = "../application-services/components/support/interrupt", version = "0.1.0" }
++sql-support = { path = "../application-services/components/support/sql", version = "0.1.0" }
++sync15 = { path = "../application-services/components/sync15", version = "0.1.0" }
++tabs = { path = "../application-services/components/tabs", version = "0.1.0" }
++viaduct = { path = "third_party/rust/viaduct", version = "0.1.0" }
++webext-storage = { path = "../application-services/components/webext-storage", version = "0.1.0" }
++suggest = { path = "third_party/rust/suggest" }
++
++metal = { path = "../metal" }
++
++[patch."https://github.com/mozilla-spidermonkey/jsparagus"]
++jsparagus = { path = "../jsparagus" }
++
++[patch."https://github.com/mozilla/neqo"]
++neqo-http3 = { path = "../neqo/neqo-http3", version = "0.6.5" }
++neqo-common = { path = "../neqo/neqo-common", version = "0.6.5" }
++neqo-transport = { path = "../neqo/neqo-transport", version = "0.6.5" }
++neqo-qpack = { path = "../neqo/neqo-qpack", version = "0.6.5" }
++neqo-crypto = { path = "../neqo/neqo-crypto", version = "0.6.5" }
++
++[patch."https://github.com/FirefoxGraphics/aa-stroke"]
++aa-stroke = { path = "../aa-stroke"}
++
++[patch."https://github.com/mozilla/audioipc"]
++audioipc2-client = { path = "../audioipc/client" }
++audioipc2-server = { path = "../audioipc/server" }
++
++[patch."https://github.com/mozilla/cubeb-coreaudio-rs"]
++cubeb-coreaudio = { path = "../cubeb-coreaudio" }
++
++[patch."https://github.com/mozilla/cubeb-pulse-rs"]
++cubeb-pulse = { path = "../cubeb-pulse" }
++
++[patch."https://github.com/jfkthame/mapped_hyph.git"]
++mapped_hyph = { path = "../mapped_hyph" }
++
++[patch."https://github.com/mozilla/mp4parse-rust"]
++mp4parse_capi = { path = "../mp4parse/mp4parse_capi", version = "0.17.0" }
+ 
+ # Patch mio 0.6 to use winapi 0.3 and miow 0.3, getting rid of winapi 0.2.
+ # There is not going to be new version of mio 0.6, mio now being >= 0.7.11.
+@@ -216,8 +247,16 @@
+ path = "third_party/rust/mio-0.6.23"
+ 
+ [patch."https://github.com/mozilla/uniffi-rs.git"]
+-uniffi = "=0.25.3"
+-uniffi_bindgen = "=0.25.3"
+-uniffi_build = "=0.25.3"
+-uniffi_macros = "=0.25.3"
+-weedle2 = "=4.0.0"
++uniffi-example-arithmetic = { path = "../uniffi-rs/examples/arithmetic" }
++uniffi-example-geometry = { path = "../uniffi-rs/examples/geometry" }
++uniffi-example-rondpoint = { path = "../uniffi-rs/examples/rondpoint" }
++uniffi-example-sprites = { path = "../uniffi-rs/examples/sprites" }
++uniffi-example-todolist = { path = "../uniffi-rs/examples/todolist" }
++
++[patch."https://github.com/FirefoxGraphics/wpf-gpu-raster"]
++wpf-gpu-raster = { path = "../wpf-gpu-raster" }
++
++[patch."https://github.com/gfx-rs/wgpu"]
++wgpu-core = { path = "../wgpu/wgpu-core" }
++wgpu-types = { path = "../wgpu/wgpu-types" }
++wgpu-hal = { path = "../wgpu/wgpu-hal" }

--- a/meta-firefox/recipes-browser/firefox/firefox.inc
+++ b/meta-firefox/recipes-browser/firefox/firefox.inc
@@ -75,7 +75,6 @@ SRC_URI += "https://ftp.mozilla.org/pub/firefox/releases/${PV}/source/firefox-${
            git://github.com/mozilla/neqo;protocol=https;branch=main;name=neqo;destsuffix=neqo \
            git://github.com/gfx-rs/wgpu.git;protocol=https;branch=trunk;name=wgpu;destsuffix=wgpu \
            git://github.com/mozilla/audioipc;protocol=https;branch=master;name=audioipc;destsuffix=audioipc \
-           git://github.com/servo/rust-cssparser;protocol=https;branch=master;name=cssparser;destsuffix=cssparser \
            git://github.com/mozilla/mp4parse-rust;protocol=https;branch=master;name=mp4parse;destsuffix=mp4parse \
            git://github.com/gfx-rs/naga;protocol=https;branch=master;name=naga;destsuffix=naga \
            "
@@ -86,14 +85,6 @@ SRCREV_FORMAT .= "_chardetng_c"
 SRCREV_chardetng_c = "ed8a4c6f900a90d4dbc1d64b856e61490a1c3570"
 SRCREV_FORMAT .= "_coremidi"
 SRCREV_coremidi = "fc68464b5445caf111e41f643a2e69ccce0b4f83"
-SRCREV_FORMAT .="_midir"
-SRCREV_midir = "519e651241e867af3391db08f9ae6400bc023e18"
-SRCREV_FORMAT .= "_jsparagus"
-SRCREV_jsparagus = "64ba08e24749616de2344112f226d1ef4ba893ae"
-SRCREV_FORMAT .= "_aa-stroke"
-SRCREV_aa-stroke = "07d3c25322518f294300e96246e09b95e118555d"
-SRCREV_FORMAT .= "_cubeb-coreaudio"
-SRCREV_cubeb-coreaudio = "93b5c01a131f65c83c11aeb317f4583405c5eb79"
 SRCREV_FORMAT .= "_mapped_hyph"
 SRCREV_mapped_hyph = "c7651a0cffff41996ad13c44f689bd9cd2192c01"
 

--- a/meta-firefox/recipes-browser/firefox/firefox_115.8.0esr.bb
+++ b/meta-firefox/recipes-browser/firefox/firefox_115.8.0esr.bb
@@ -8,7 +8,6 @@ LIC_FILES_CHKSUM = "file://toolkit/content/license.html;md5=1b074cb88f7e9794d795
 
 SRC_URI += "git://github.com/hsivonen/packed_simd.git;protocol=https;branch=0_3_9;name=packed-simd;destsuffix=packed_simd \
             git://github.com/gfx-rs/d3d12-rs;protocol=https;branch=master;name=d3d12-rs;destsuffix=d3d12-rs \
-            git://git@github.com/dtolnay/syn.git;protocol=https;branch=master;name=syn;destsuffix=syn \
             git://github.com/glandium/warp.git;protocol=https;branch=pemfile;name=warp;destsuffix=warp \
             file://debian-hacks/Work-around-bz-1775202-to-fix-FTBFS-on-ppc64el.patch"
 
@@ -20,8 +19,6 @@ SRCREV_FORMAT .= "_application-services"
 SRCREV_application-services = "86c84c217036c12283d19368867323a66bf35883"
 SRCREV_FORMAT .= "_packed-simd"
 SRCREV_packed-simd = "e588ceb568878e1a3156ea9ce551d5b63ef0cdc4"
-SRCREV_FORMAT .= "_syn"
-SRCREV_syn = "43632bfb6c78ee1f952645a268ab1ac4af162977"
 
 SRCREV_FORMAT .= "_d3d12-rs"
 SRCREV_d3d12-rs = "b940b1d71ab7083ae80eec697872672dc1f2bd32"
@@ -41,11 +38,8 @@ SRCREV_naga = "b99d58ea435090e561377949f428bce2c18451bb"
 SRCREV_FORMAT .= "_uniffi-rs"
 SRCREV_uniffi-rs = "bc7ff8977bf38d0fdd1a458810b14f434d4dc4de"
 
-SRCREV_FORMAT .= "_cssparser"
-SRCREV_cssparser = "45bc47e2bcb846f1efb5aea156be5fe7d18624bf"
-
-SRCREV_FORMAT .= "_wgpu"
-SRCREV_wgpu = "f71a1bc736fde37509262ca03e91d8f56a13aeb5"
+# SRCREV_FORMAT .= "_cssparser"
+# SRCREV_cssparser = "45bc47e2bcb846f1efb5aea156be5fe7d18624bf"
 
 SRCREV_FORMAT .= "_audioipc"
 SRCREV_audioipc = "0b51291d2483a17dce3e300c7784b369e02bee73"
@@ -61,3 +55,12 @@ SRCREV_cubeb-pulse = "cf48897be5cbe147d051ebbbe1eaf5fd8fb6bbc9"
 
 SRCREV_FORMAT .="_midir"
 SRCREV_midir = "519e651241e867af3391db08f9ae6400bc023e18"
+
+SRCREV_FORMAT .= "_cubeb-coreaudio"
+SRCREV_cubeb-coreaudio = "93b5c01a131f65c83c11aeb317f4583405c5eb79"
+
+SRCREV_FORMAT .= "_aa-stroke"
+SRCREV_aa-stroke = "07d3c25322518f294300e96246e09b95e118555d"
+
+SRCREV_FORMAT .= "_jsparagus"
+SRCREV_jsparagus = "64ba08e24749616de2344112f226d1ef4ba893ae"

--- a/meta-firefox/recipes-browser/firefox/firefox_123.0.1.bb
+++ b/meta-firefox/recipes-browser/firefox/firefox_123.0.1.bb
@@ -11,12 +11,11 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/firefox-stable:"
 SRC_URI += "git://github.com/franziskuskiefer/cose-rust;protocol=https;branch=master;name=cose-rust;destsuffix=cose-rust \
             git://github.com/rust-minidump/minidump-writer.git;protocol=https;branch=main;name=minidump-writer;destsuffix=minidump-writer \
             git://github.com/rust-minidump/rust-minidump;protocol=https;branch=main;name=minidump-common;destsuffix=minidump-common \
-            git://github.com/rust-diplomat/diplomat;protocol=https;branch=main;name=diplomat;destsuffix=diplomat \
-            git://github.com/unicode-org/icu4x;protocol=https;branch=main;name=icu4x;destsuffix=icu4x \
-            git://github.com/hsivonen/packed_simd.git;protocol=https;branch=0_3_8;name=packed-simd;destsuffix=packed_simd \
+            git://github.com/hsivonen/packed_simd.git;protocol=https;branch=master;name=packed-simd;destsuffix=packed_simd \
             git://github.com/mozilla/mp4parse-rust;protocol=https;branch=master;name=mp4parse;destsuffix=mp4parse \
             git://github.com/gfx-rs/metal-rs;protocol=https;branch=master;name=metal;destsuffix=metal \
-            git://github.com/seanmonstar/warp;protocol=https;branch=master;name=warp;destsuffix=warp"
+            git://github.com/seanmonstar/warp;protocol=https;branch=master;name=warp;destsuffix=warp \
+            git://github.com/servo/rust-cssparser;protocol=https;branch=master;name=cssparser;destsuffix=cssparser"
 
 SRC_URI[sha256sum] = "d5dcb955b65e0f164a90cac0760724486e36e896221b98f244801dfd045d741c"
 
@@ -28,12 +27,8 @@ SRCREV_FORMAT .= "_minidump-writer"
 SRCREV_minidump-writer = "99c561931fe8cf1fa2135b3f23ff6588bef8fd1e"
 SRCREV_FORMAT .= "_minidump-common"
 SRCREV_minidump-common = "c3de84b061339c686a572fb9f059e7ba3fad38d6"
-SRCREV_FORMAT .= "_diplomat"
-SRCREV_diplomat = "8d125999893fedfdf30595e97334c21ec4b18da9"
-SRCREV_FORMAT .= "_icu4x"
-SRCREV_icu4x = "14e9a3a9857be74582abe2dfa7ab799c5eaac873"
 SRCREV_FORMAT .= "_packed-simd"
-SRCREV_packed-simd = "412f9a0aa556611de021bde89dee8fefe6e0fbbd"
+SRCREV_packed-simd = "d938e39bee9bc5c222f5f2f2a0df9e53b5ce36ae"
 
 
 SRCREV_FORMAT .= "_mp4parse"
@@ -45,7 +40,7 @@ SRCREV_wgpu = "c6eea50b04127abe2340b93141123312baf5414b"
 SRCREV_FORMAT .= "_naga"
 SRCREV_naga = "92e41b43e437146b5d946eb238de963be1168016"
 SRCREV_FORMAT .= "_uniffi-rs"
-SRCREV_uniffi-rs = "c0e64b839018728d8153ce1758d391b7782e2e21"
+SRCREV_uniffi-rs = "afb29ebdc1d9edf15021b1c5332fc9f285bbe13b"
 SRCREV_FORMAT .= "_metal"
 SRCREV_metal = "f507da4686234e658f31de54d2aa0dfa8abd236b"
 
@@ -63,6 +58,13 @@ SRCREV_cubeb-pulse = "c04c4d2c7f2291cb81a1c48f5a8c425748f18cd8"
 
 SRCREV_FORMAT .="_midir"
 SRCREV_midir = "85156e360a37d851734118104619f86bd18e94c6"
+
+SRCREV_FORMAT .= "_cubeb-coreaudio"
+SRCREV_cubeb-coreaudio = "89abc256a2eab3398f880e114b2d8308f5bc1d1a"
+SRCREV_FORMAT .= "_aa-stroke"
+SRCREV_aa-stroke = "ed4206ea11703580cd1d4fc63371a527b29d8252"
+SRCREV_FORMAT .= "_jsparagus"
+SRCREV_jsparagus = "61f399c53a641ebd3077c1f39f054f6d396a633c"
 
 PACKAGECONFIG[x11-only] = "--enable-default-toolkit=cairo-gtk3-x11-only,,,,,wayland-only"
 PACKAGECONFIG[wayland-only] = "--enable-default-toolkit=cairo-gtk3-wayland-only,,virtual/egl,,,x11-only"

--- a/meta-firefox/recipes-browser/firefox/firefox_crates_esr.inc
+++ b/meta-firefox/recipes-browser/firefox/firefox_crates_esr.inc
@@ -363,7 +363,7 @@ SRC_URI += "crate://crates.io/adler/1.0.2 \
             crate://crates.io/strsim/0.10.0 \
             crate://crates.io/svg_fmt/0.4.1 \
             crate://crates.io/syn/1.0.107 \
-            crate://crates.io/syn/2.0.32 \
+            crate://crates.io/syn/2.0.38 \
             crate://crates.io/synstructure/0.12.6 \
             crate://crates.io/tempfile/3.3.0 \
             crate://crates.io/termcolor/1.2.0 \
@@ -812,7 +812,7 @@ SRC_URI[static_assertions-1.1.0.sha256sum] = "a2eb9349b6444b326872e140eb1cf5e7c5
 SRC_URI[strsim-0.10.0.sha256sum] = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 SRC_URI[svg_fmt-0.4.1.sha256sum] = "8fb1df15f412ee2e9dfc1c504260fa695c1c3f10fe9f4a6ee2d2184d7d6450e2"
 SRC_URI[syn-1.0.107.sha256sum] = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
-SRC_URI[syn-2.0.32.sha256sum] = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
+SRC_URI[syn-2.0.38.sha256sum] = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 SRC_URI[synstructure-0.12.6.sha256sum] = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 SRC_URI[tempfile-3.3.0.sha256sum] = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 SRC_URI[termcolor-1.2.0.sha256sum] = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"


### PR DESCRIPTION
There are a number of seemingly magic commit hashes in the recipes from seemingly random repositories. This changeset documents all of these hashes, where they are coming from, and why that particular commit has is used.

Beside that I also went through all the dependencies, and removed the ones that silently became obsolete/unused.