### PR TITLE
Firefox: Update bindgen crate for ESR to be able to compile with clang18

### DIFF
--- a/meta-firefox/recipes-browser/firefox/firefox-esr/0004-fix-compilation-with-clang18.patch
+++ b/meta-firefox/recipes-browser/firefox/firefox-esr/0004-fix-compilation-with-clang18.patch
@@ -1,0 +1,72 @@
+Make sure that Firefox can be compiled with clang-18. Using the original
+bindgen crate, the compilation tripped on the following llvm commit:
+
+https://github.com/llvm/llvm-project/commit/7091ca1ae3a87479b6febdf1c3a324d707c633d9
+
+Upstream-Status: Inappropriate
+--- ./build/workspace-hack/Cargo.toml	2024-04-23 11:07:32.693320001 +0200
++++ ./build/workspace-hack/Cargo.toml	2024-04-23 11:07:45.550114940 +0200
+@@ -33,7 +33,7 @@
+ serde_derive = { features = ["default", "deserialize_in_place"], version = "1.0.66" }
+ quote = { features = ["default", "proc-macro"], version = "1.0" }
+ libc = { features = ["default", "std", "use_std"], version = "0.2" }
+-bindgen = { default-features = false, features = ["runtime"], version = "0.64" }
++bindgen = { default-features = false, features = ["runtime"], version = "0.69.4" }
+ 
+ [target."cfg(windows)".dependencies.winapi]
+ version = "0.3.6"
+--- ./netwerk/test/http3server/Cargo.toml	2024-04-23 11:11:53.996152320 +0200
++++ ./netwerk/test/http3server/Cargo.toml	2024-04-23 11:12:11.952865917 +0200
+@@ -27,7 +27,7 @@
+ 
+ # Make sure to use bindgen's runtime-loading of libclang, as it allows for a wider range of clang versions to be used
+ [build-dependencies]
+-bindgen = {version = "0.64", default-features = false, features = ["runtime"] }
++bindgen = {version = "0.69.4", default-features = false, features = ["runtime"] }
+ 
+ [[bin]]
+ name = "http3server"
+--- ./security/manager/ssl/builtins/Cargo.toml	2024-04-23 11:15:47.877422002 +0200
++++ ./security/manager/ssl/builtins/Cargo.toml	2024-04-23 11:15:56.513284263 +0200
+@@ -10,7 +10,7 @@
+ smallvec = { version = "1.9.0", features = ["const_new"] }
+ 
+ [build-dependencies]
+-bindgen = { default-features = false, features = ["runtime"], version = "0.64" }
++bindgen = { default-features = false, features = ["runtime"], version = "0.69.4" }
+ nom = "7.1.1"
+ 
+ [lib]
+--- ./tools/profiler/rust-api/Cargo.toml	2024-04-23 11:20:03.246319871 +0200
++++ ./tools/profiler/rust-api/Cargo.toml	2024-04-23 11:20:10.969195339 +0200
+@@ -14,7 +14,7 @@
+ 
+ [build-dependencies]
+ lazy_static = "1"
+-bindgen = {version = "0.64", default-features = false}
++bindgen = {version = "0.69.4", default-features = false}
+ mozbuild = "0.1"
+ 
+ [features]
+--- ./build/rust/bindgen/Cargo.toml	2024-04-23 11:29:11.516478991 +0200
++++ ./build/rust/bindgen/Cargo.toml	2024-04-23 11:29:19.829344946 +0200
+@@ -8,7 +8,7 @@
+ path = "lib.rs"
+ 
+ [dependencies.bindgen]
+-version = "0.64.0"
++version = "0.69.4"
+ default-features = false
+ 
+ [features]
+--- ./servo/components/style/Cargo.toml	2024-04-23 11:33:46.418046192 +0200
++++ ./servo/components/style/Cargo.toml	2024-04-23 11:34:00.513820782 +0200
+@@ -83,7 +83,7 @@
+ [build-dependencies]
+ lazy_static = "1"
+ log = { version = "0.4", features = ["std"] }
+-bindgen = {version = "0.64", optional = true, default-features = false}
++bindgen = {version = "0.69.4", optional = true, default-features = false}
+ regex = {version = "1.0", optional = true, default-features = false, features = ["perf", "std"]}
+ walkdir = "2.1.4"
+ toml = {version = "0.5", optional = true, default-features = false}

--- a/meta-firefox/recipes-browser/firefox/firefox_115.10.0esr.bb
+++ b/meta-firefox/recipes-browser/firefox/firefox_115.10.0esr.bb
@@ -10,7 +10,8 @@ SRC_URI += "git://github.com/hsivonen/packed_simd.git;protocol=https;branch=0_3_
             git://github.com/gfx-rs/d3d12-rs;protocol=https;branch=master;name=d3d12-rs;destsuffix=d3d12-rs \
             git://github.com/glandium/warp.git;protocol=https;branch=pemfile;name=warp;destsuffix=warp \
             git://github.com/gfx-rs/naga;protocol=https;branch=master;name=naga;destsuffix=naga \
-            file://debian-hacks/Work-around-bz-1775202-to-fix-FTBFS-on-ppc64el.patch"
+            file://debian-hacks/Work-around-bz-1775202-to-fix-FTBFS-on-ppc64el.patch \
+            file://0004-fix-compilation-with-clang18.patch"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/firefox-esr:"
 

--- a/meta-firefox/recipes-browser/firefox/firefox_crates_esr.inc
+++ b/meta-firefox/recipes-browser/firefox/firefox_crates_esr.inc
@@ -33,7 +33,7 @@ SRC_URI += "crate://crates.io/adler/1.0.2 \
             crate://crates.io/basic-toml/0.1.4 \
             crate://crates.io/bhttp/0.3.1 \
             crate://crates.io/bincode/1.3.3 \
-            crate://crates.io/bindgen/0.64.0 \
+            crate://crates.io/bindgen/0.69.4 \
             crate://crates.io/bit-set/0.5.3 \
             crate://crates.io/bit-vec/0.6.3 \
             crate://crates.io/bitflags/1.3.2 \
@@ -67,7 +67,7 @@ SRC_URI += "crate://crates.io/adler/1.0.2 \
             crate://crates.io/core-graphics-types/0.1.1 \
             crate://crates.io/core-graphics/0.22.3 \
             crate://crates.io/core-text/19.2.0 \
-            crate://crates.io/coreaudio-sys/0.2.12 \
+            crate://crates.io/coreaudio-sys/0.2.14 \
             crate://crates.io/coremidi-sys/3.1.0 \
             crate://crates.io/coremidi/0.6.0 \
             crate://crates.io/cose-c/0.1.5 \
@@ -296,7 +296,7 @@ SRC_URI += "crate://crates.io/adler/1.0.2 \
             crate://crates.io/pulse/0.3.0 \
             crate://crates.io/qlog/0.4.0 \
             crate://crates.io/quick-error/1.2.3 \
-            crate://crates.io/quote/1.0.23 \
+            crate://crates.io/quote/1.0.28 \
             crate://crates.io/rand_chacha/0.3.1 \
             crate://crates.io/rand_core/0.6.4 \
             crate://crates.io/rand/0.8.5 \
@@ -482,7 +482,7 @@ SRC_URI[base64-0.21.0.sha256sum] = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab
 SRC_URI[basic-toml-0.1.4.sha256sum] = "7bfc506e7a2370ec239e1d072507b2a80c833083699d3c6fa176fbb4de8448c6"
 SRC_URI[bhttp-0.3.1.sha256sum] = "1300dca7a20730cce82c33fbf8795862556645ef5e9ee835390278c3fe1eb1d0"
 SRC_URI[bincode-1.3.3.sha256sum] = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-SRC_URI[bindgen-0.64.0.sha256sum] = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
+SRC_URI[bindgen-0.69.4.sha256sum] = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 SRC_URI[bit-set-0.5.3.sha256sum] = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 SRC_URI[bit-vec-0.6.3.sha256sum] = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 SRC_URI[bitflags-1.3.2.sha256sum] = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
@@ -516,7 +516,7 @@ SRC_URI[core-foundation-sys-0.8.3.sha256sum] = "5827cebf4670468b8772dd191856768a
 SRC_URI[core-graphics-0.22.3.sha256sum] = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
 SRC_URI[core-graphics-types-0.1.1.sha256sum] = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
 SRC_URI[core-text-19.2.0.sha256sum] = "99d74ada66e07c1cefa18f8abfba765b486f250de2e4a999e5727fc0dd4b4a25"
-SRC_URI[coreaudio-sys-0.2.12.sha256sum] = "f034b2258e6c4ade2f73bf87b21047567fb913ee9550837c2316d139b0262b24"
+SRC_URI[coreaudio-sys-0.2.14.sha256sum] = "f3120ebb80a9de008e638ad833d4127d50ea3d3a960ea23ea69bc66d9358a028"
 SRC_URI[coremidi-0.6.0.sha256sum] = "1a7847ca018a67204508b77cb9e6de670125075f7464fff5f673023378fa34f5"
 SRC_URI[coremidi-sys-3.1.0.sha256sum] = "79a6deed0c97b2d40abbab77e4c97f81d71e162600423382c277dd640019116c"
 SRC_URI[cose-0.1.4.sha256sum] = "72fa26cb151d3ae4b70f63d67d0fed57ce04220feafafbae7f503bef7aae590d"
@@ -745,7 +745,7 @@ SRC_URI[prost-derive-0.8.0.sha256sum] = "600d2f334aa05acb02a755e217ef1ab6dea4d51
 SRC_URI[pulse-0.3.0.sha256sum] = "88b7efc7519ba9fdddafe59e48ccdc6274a3fa6dbb4fc4a173dbc3f14860ab6d"
 SRC_URI[qlog-0.4.0.sha256sum] = "8777d5490145d6907198d48b3a907447689ce80e071b3d8a16a9d9fb3df02bc1"
 SRC_URI[quick-error-1.2.3.sha256sum] = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-SRC_URI[quote-1.0.23.sha256sum] = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+SRC_URI[quote-1.0.28.sha256sum] = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 SRC_URI[rand_chacha-0.3.1.sha256sum] = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 SRC_URI[rand_core-0.6.4.sha256sum] = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 SRC_URI[rand-0.8.5.sha256sum] = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"


### PR DESCRIPTION
Firefox ESR can't be compiled by default with clang-18, the way extern function declarations are handled has changed:
https://github.com/llvm/llvm-project/commit/7091ca1ae3a87479b6febdf1c3a324d707c633d9

Updating bindgen makes it compatible with the latest clang version.

Closes #76 