### PR TITLE
firefox: remove mickledore from supported yocto releases

### DIFF
--- a/meta-firefox/README.md
+++ b/meta-firefox/README.md
@@ -23,11 +23,10 @@ Firefox can be successfully compiled with the following dependencies and branche
 | ------------- | ---------- | ------- | ---------- | --------- |
 | Dunfell       | [Dunfell](https://github.com/openembedded/meta-openembedded/commit/300be975359fdb3a3b2bf7c6fe15dea7acac575d) | [Dunfell](https://git.yoctoproject.org/poky/commit/?h=dunfell&id=aeac1034661725b5c83e79f76238429fb236b090)        | [Dunfell](https://github.com/kraj/meta-clang/commit/67ac939d47b3dfc383fec7244e4a0ff85ca4340f)           | [Master](https://github.com/meta-rust/meta-rust/commit/e3082dc0728023b121d648da4c5c856943b5e425) |
 | Kirkstone     | [Kirkstone](https://github.com/openembedded/meta-openembedded/commit/529620141e773080a6a7be4615fb7993204af883)  | [Kirkstone](https://git.yoctoproject.org/poky/commit/?h=kirkstone&id=75239ddd8d67c00139c6e88c1c2a790b471b12c5) | [Kirkstone](https://github.com/kraj/meta-clang/commit/2d08d6bf376a1e06c53164fd6283b03ec2309da4) | [Master](https://github.com/meta-rust/meta-rust/commit/e3082dc0728023b121d648da4c5c856943b5e425) |
-| Mickledore    | [Mickledore](https://github.com/openembedded/meta-openembedded/commit/922f41b39f364e5b6be596b4b51e0fb37ffe1971) | [Mickledore](https://git.yoctoproject.org/poky/commit/?h=mickledore&id=a57506c46d92bf0767060102d2139be06d46f575) | [Master](https://github.com/kraj/meta-clang/commit/869df95b61ba44a7ad6bc57da8a31e459eec5059)  | N/A       |
 | Nanbield      | [Nanbield](https://github.com/openembedded/meta-openembedded/commit/278c3f75e32f38f71bb52d161fe06bcb6f6bdd2f) | [Nanbield](https://git.yoctoproject.org/poky/commit/?h=nanbield&id=0e351df0425968fd58983e445391012e64f7f4ad)  | [Master](https://github.com/kraj/meta-clang/commit/869df95b61ba44a7ad6bc57da8a31e459eec5059) | N/A       |
 | Scarthgap     | [master-next](https://github.com/openembedded/meta-openembedded/commit/a64b63c0a1ae74199043cf699cf93a171364980d) | [Scarthgap](https://git.yoctoproject.org/poky/commit/?h=scarthgap&id=b5624ee5643d881afa004571a096a189ab5389b5) | [Nanbield](https://github.com/kraj/meta-clang/commit/5170ec9cdfe215fcef146fa9142521bfad1d7d6c) | N/A       |
 
-Mickledore, Nanbield and Scarthgap work with the Rust recipes included in poky.
+Nanbield and Scarthgap work with the Rust recipes included in poky.
 
 Kirkstone however has a too old Rust version, and Dunfell has no Rust.
 These versions require the meta-rust layer also. For Kirkstone make sure to set the 

--- a/meta-firefox/conf/layer.conf
+++ b/meta-firefox/conf/layer.conf
@@ -105,6 +105,6 @@ BBFILE_PATTERN_firefox-browser-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_firefox-browser-layer = "7"
 
 LAYERVERSION_firefox-browser-layer = "2"
-LAYERSERIES_COMPAT_firefox-browser-layer = "dunfell kirkstone mickledore nanbield scarthgap"
+LAYERSERIES_COMPAT_firefox-browser-layer = "dunfell kirkstone nanbield scarthgap"
 
 LAYERDEPENDS_firefox-browser-layer = "clang-layer core openembedded-layer"


### PR DESCRIPTION
Closes #80 