### PR TITLE
pin each test-image layer to a specific commit

### DIFF
--- a/meta-firefox/kas/kirkstone-esr-aarch64-test.yml
+++ b/meta-firefox/kas/kirkstone-esr-aarch64-test.yml
@@ -10,7 +10,7 @@ machine: raspberrypi3-64
 
 repos:
   meta-rpi:
-    refspec: kirkstone
+    refspec: "d7544f35756d87834e8b4bf3e3e733c771d380ae"
 
 local_conf_header:
   kirkstone-esr-arm: |

--- a/meta-firefox/kas/kirkstone-esr-arm-test.yml
+++ b/meta-firefox/kas/kirkstone-esr-arm-test.yml
@@ -10,7 +10,7 @@ machine: raspberrypi3
 
 repos:
   meta-rpi:
-    refspec: kirkstone
+    refspec: "d7544f35756d87834e8b4bf3e3e733c771d380ae"
 
 local_conf_header:
   kirkstone-esr-arm: |

--- a/meta-firefox/kas/kirkstone-latest-aarch64-test.yml
+++ b/meta-firefox/kas/kirkstone-latest-aarch64-test.yml
@@ -10,7 +10,7 @@ machine: raspberrypi3-64
 
 repos:
   meta-rpi:
-    refspec: kirkstone
+    refspec: "d7544f35756d87834e8b4bf3e3e733c771d380ae"
 
 local_conf_header:
   kirkstone-latest-aarch64: |

--- a/meta-firefox/kas/kirkstone-latest-arm-test.yml
+++ b/meta-firefox/kas/kirkstone-latest-arm-test.yml
@@ -10,7 +10,7 @@ machine: raspberrypi3
 
 repos:
   meta-rpi:
-    refspec: kirkstone
+    refspec: "d7544f35756d87834e8b4bf3e3e733c771d380ae"
 
 local_conf_header:
   kirkstone-latest-arm: |

--- a/meta-firefox/kas/repos/dunfell.yml
+++ b/meta-firefox/kas/repos/dunfell.yml
@@ -6,11 +6,11 @@ header:
 
 repos:
   meta-oe:
-    refspec: dunfell
+    refspec: "bf0da59a92e9b9b10ec5e9de4f21daab7499dbd8"
   poky:
-    refspec: dunfell
+    refspec: "63d05fc061006bf1a88630d6d91cdc76ea33fbf2"
   meta-clang:
-    refspec: dunfell-clang12
+    refspec: "e8a5e806b48a36046ef78a95f4d4cd428e8ea4c2"
   meta-rust:
     # last revision that supports Dunfell, along with the CMake version shipped with poky
     refspec: "d42984ff9a9fad9ced37d95a89af1b2b84f957e9"

--- a/meta-firefox/kas/repos/kirkstone.yml
+++ b/meta-firefox/kas/repos/kirkstone.yml
@@ -6,11 +6,11 @@ header:
 
 repos:
   meta-oe:
-    refspec: kirkstone
+    refspec: "4052c97dc83d0c88fc277d6fc1815e0699020daa"
   poky:
-    refspec: kirkstone
+    refspec: "6bd3969d32730538608e680653e032e66958fe84"
   meta-clang:
-    refspec: kirkstone
+    refspec: "2ed384c64e206016c628451672c688e59944381b"
   meta-rust:
     refspec: "a5136be2ba408af1cc8afcde1c8e3d787dadd934"
 

--- a/meta-firefox/kas/repos/scarthgap.yml
+++ b/meta-firefox/kas/repos/scarthgap.yml
@@ -5,8 +5,8 @@ header:
 
 repos:
   meta-oe:
-    refspec: scarthgap
+    refspec: "18f939a5fb37528a5415b05077ece383c346a119"
   poky:
-    refspec: scarthgap
+    refspec: "a099b484c5b245a335a5ec9b293638e1362383ae"
   meta-clang:
     refspec: "989ff6a4e7db59f01d511727135610006124ead2"


### PR DESCRIPTION
Trying to speed up test image builds by pinning all layer revisions to a specific commit (except for styhead, which is the tip of master for now)