### PR TITLE
firefox: remove "disable-elf-hack" from 32-bit arm's OECONF

### DIFF
--- a/meta-firefox/classes/mozilla.bbclass
+++ b/meta-firefox/classes/mozilla.bbclass
@@ -7,7 +7,6 @@ EXTRA_OECONF = "--target=${TARGET_SYS} --host=${BUILD_SYS} \
                 --with-toolchain-prefix=${TARGET_SYS}- \
                 --prefix=${prefix} \
                 --libdir=${libdir}"
-EXTRA_OECONF:append:arm = " --disable-elf-hack"
 EXTRA_OECONF:append:x86 = " --disable-elf-hack"
 EXTRA_OECONF:append:x86-64 = " --disable-elf-hack"
 SELECTED_OPTIMIZATION = "-Os -fsigned-char -fno-strict-aliasing"


### PR DESCRIPTION
This argument is causing the crash on 32-bit arm targets (see issue #110)