### PR TITLE
firefox: disable sandbox for 32-bit arm

### DIFF
--- a/meta-firefox/classes/mozilla.bbclass
+++ b/meta-firefox/classes/mozilla.bbclass
@@ -7,8 +7,8 @@ EXTRA_OECONF = "--target=${TARGET_SYS} --host=${BUILD_SYS} \
                 --with-toolchain-prefix=${TARGET_SYS}- \
                 --prefix=${prefix} \
                 --libdir=${libdir}"
-EXTRA_OECONF:append:x86 = " --disable-elf-hack"
-EXTRA_OECONF:append:x86-64 = " --disable-elf-hack"
+
+EXTRA_OECONF:append:arm = " --disable-sandbox "
 SELECTED_OPTIMIZATION = "-Os -fsigned-char -fno-strict-aliasing"
 
 export CROSS_COMPILE = "1"


### PR DESCRIPTION
When content sandbox is enabled, 32-bit arm build keeps crashing - at least the tabs only display this error. It looks like that due to some sandbox restrictions on this arch it is not able to load any fonts, that makes it give up on everything.

The build works also with sandbox, if MOZ_DISABLE_CONTENT_SANDBOX=1 environment variable is set.

For now, just disable sandbox for this arch, and investigate it later.

Also, remove "disable-elf-hack" option for x86, as it has no effect on its own.